### PR TITLE
fix: derive daily energy baseline from InfluxQL instead of a 00:00-only metric

### DIFF
--- a/roles/sensor_collector/files/sensors_to_prometheus.py
+++ b/roles/sensor_collector/files/sensors_to_prometheus.py
@@ -100,17 +100,11 @@ def output_prometheus(device_name, values):
 
 
 def output_prometheus_remo(data):
-    values = {
+    output_prometheus(data['DeviceName'], {
         'CumulativeEnergy': data['CumulativeEnergy'],
         'RevCumulativeEnergy': data['RevCumulativeEnergy'],
         'Watt': data['Watt'],
-    }
-    output_prometheus(data['DeviceName'], values)
-
-    # 00:00 の場合のみ、その日の起点値として専用のpromデータを出力
-    if master_date.strftime('%H%M') == '0000':
-        output_prometheus(data['DeviceName'],
-                          {f'{suffix}_0000': value for suffix, value in values.items()})
+    })
 
 
 def output_prometheus_hub2(data):


### PR DESCRIPTION
## Summary

- Dropped the `_0000`-suffixed baseline gauges, which were written only during the 00:00 cron run and thus had a ~1-minute exposure window — a Nature Remo API retry delay or scrape phase shift could silently drop the day's baseline
- The base `CumulativeEnergy` / `RevCumulativeEnergy` series are already written every minute, so the Grafana panel now derives the daily baseline with `first("value") ... GROUP BY time(1d) tz('Asia/Tokyo')`, removing the cron/scrape timing coupling and the JST/UTC day-boundary ambiguity

Closes #9

## 補足（任意）

- Stacked on #8 (role rename); base branch is `refactor/rename-inkbird-to-sensor-collector` and will auto-retarget to main once #8 merges
- The Grafana panel query is updated manually in the web UI (dashboards are not managed in this repo)
- Verified in production after the JST midnight rollover

🤖 Generated with [Claude Code](https://claude.com/claude-code)