### PR TITLE
fix: land daily energy baseline change on main (_0000 removal)

### DIFF
--- a/roles/sensor_collector/files/sensors_to_prometheus.py
+++ b/roles/sensor_collector/files/sensors_to_prometheus.py
@@ -100,17 +100,11 @@ def output_prometheus(device_name, values):
 
 
 def output_prometheus_remo(data):
-    values = {
+    output_prometheus(data['DeviceName'], {
         'CumulativeEnergy': data['CumulativeEnergy'],
         'RevCumulativeEnergy': data['RevCumulativeEnergy'],
         'Watt': data['Watt'],
-    }
-    output_prometheus(data['DeviceName'], values)
-
-    # 00:00 の場合のみ、その日の起点値として専用のpromデータを出力
-    if master_date.strftime('%H%M') == '0000':
-        output_prometheus(data['DeviceName'],
-                          {f'{suffix}_0000': value for suffix, value in values.items()})
+    })
 
 
 def output_prometheus_hub2(data):


### PR DESCRIPTION
## Summary

- Re-lands the daily-baseline fix on `main`. PR #10 carried this exact commit but its base branch was `refactor/rename-inkbird-to-sensor-collector` and was never retargeted to `main` after #8 merged, so it merged into the rename branch and `main` never received it.
- The change: dropped the `_0000`-suffixed baseline gauges (written only during the 00:00 cron run, ~1-minute exposure window — an API retry delay or scrape phase shift could silently drop the day's baseline). The base `CumulativeEnergy` / `RevCumulativeEnergy` series are already written every minute, so the Grafana panel derives the daily baseline with `first("value") ... GROUP BY time(1d) tz('Asia/Tokyo')`.

Closes #9

## 補足（任意）

- Production already runs this script (applied manually during the role-rename migration); this PR only reconciles `main`'s history.
- The stale `refactor/rename-inkbird-to-sensor-collector` branch (holding PR #10's merge commit, which never reaches main) is being deleted.
- Verified in production after the JST midnight rollover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)